### PR TITLE
Include the RXL as metanorma output extension

### DIFF
--- a/sources/document.adoc
+++ b/sources/document.adoc
@@ -32,7 +32,7 @@
 :comment: ### Metanorma flavor; mandatory
 :mn-document-class: ogc
 :comment: ### Desired output formats; mandatory
-:mn-output-extensions: xml,html,doc,pdf
+:mn-output-extensions: rxl,xml,html,doc,pdf
 :comment: ### Enable local relaton cache for quick inclusion of prefetched references; optional. For further information, visit: https://www.metanorma.com/author/ref/document-attributes/#caches, https://www.metanorma.com/author/topics/building/reference-lookup/#lookup-result-caching
 :local-cache-only:
 :comment: ### Encode all images in HTML output as inline data-URIs; optional


### PR DESCRIPTION
This commit commits adds the `rxl` file extension to be generated during the metanorma compilation and later this would be used to combined these file and include those in the `index.html`